### PR TITLE
style: remove gradient from hero heading

### DIFF
--- a/components/HeroSection.js
+++ b/components/HeroSection.js
@@ -90,7 +90,7 @@ export default function HeroSection({ overviewLeftRef, overviewRightRef }) {
                         
                         <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-foreground leading-tight">
                             I build{" "}
-                            <span className="text-transparent bg-clip-text bg-gradient-to-r from-primary via-secondary to-accent">
+                            <span className="text-primary">
                                 geospatial systems
                             </span>{" "}
                             that make sense of complex data


### PR DESCRIPTION
Replaces gradient text with solid primary color for cleaner look.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Purely presentational tweak to the hero section heading.
> 
> - In `components/HeroSection.js`, changed `geospatial systems` span from gradient (`text-transparent bg-clip-text bg-gradient-to-r ...`) to solid `text-primary`
> - No logic, markup structure, or behavioral changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9246e3f680ae7c7f8cf5e2daeb3aa035f4f2269a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->