### PR TITLE
feat: Mobile Optimization for Globe & Chat

### DIFF
--- a/components/ChatTerminal.jsx
+++ b/components/ChatTerminal.jsx
@@ -56,17 +56,40 @@ export default function ChatTerminal({ onCommand }) {
     }
   };
 
+  const [isOpen, setIsOpen] = useState(true);
+
   return (
-    <div className="fixed bottom-8 right-8 w-96 h-96 bg-[#0f172a]/95 backdrop-blur-md border border-[#1e293b] rounded-lg shadow-2xl flex flex-col z-50 font-mono text-sm overflow-hidden">
-      {/* Header */}
-      <div className="bg-[#1e293b] p-3 flex items-center gap-2 border-b border-[#334155]">
-        <div className="w-3 h-3 rounded-full bg-red-500"></div>
-        <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
-        <div className="w-3 h-3 rounded-full bg-green-500"></div>
-        <span className="ml-2 text-slate-300 font-bold flex items-center gap-2">
-          <FiTerminal /> ORBITAL_CMD
-        </span>
-      </div>
+    <>
+      {/* Mobile Toggle Button */}
+      {!isOpen && (
+        <button 
+          onClick={() => setIsOpen(true)}
+          className="fixed bottom-4 right-4 z-50 p-3 bg-[#0f172a] border border-[#22d3ee]/30 rounded-full shadow-lg text-[#22d3ee] animate-bounce"
+        >
+          <FiTerminal size={24} />
+        </button>
+      )}
+
+      {/* Terminal Window */}
+      <div className={`fixed z-50 transition-all duration-300 ease-in-out
+        ${isOpen ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0 pointer-events-none'}
+        bottom-0 left-0 right-0 h-[50vh] w-full md:bottom-8 md:right-8 md:left-auto md:h-96 md:w-96 
+        bg-[#0f172a]/95 backdrop-blur-md border-t md:border border-[#1e293b] md:rounded-lg shadow-2xl flex flex-col font-mono text-sm overflow-hidden`}
+      >
+        {/* Header */}
+        <div className="bg-[#1e293b] p-3 flex items-center justify-between border-b border-[#334155]">
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 rounded-full bg-red-500"></div>
+            <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
+            <div className="w-3 h-3 rounded-full bg-green-500"></div>
+            <span className="ml-2 text-slate-300 font-bold flex items-center gap-2">
+              <FiTerminal /> ORBITAL_CMD
+            </span>
+          </div>
+          <button onClick={() => setIsOpen(false)} className="md:hidden text-slate-400">
+            ✕
+          </button>
+        </div>
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto p-4 space-y-3">
@@ -97,13 +120,15 @@ export default function ChatTerminal({ onCommand }) {
             onChange={(e) => setInput(e.target.value)}
             placeholder="Enter command..."
             className="flex-1 bg-transparent text-slate-200 outline-none placeholder:text-slate-600"
-            autoFocus
+            // Remove autoFocus on mobile to prevent keyboard pop-up
+            autoFocus={typeof window !== 'undefined' && window.innerWidth > 768}
           />
           <button type="submit" className="text-slate-400 hover:text-white">
             <FiSend />
           </button>
         </div>
       </form>
-    </div>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Description
Optimizes the immersive experience for mobile devices.

### Key Changes
- **📱 Responsive Chat Terminal**: 
  - Collapses into a floating button on mobile.
  - Slides up from bottom (half-screen) when active.
  - Disables auto-focus to prevent keyboard pop-up on load.
- **🌍 Lightweight Globe**:
  - Detects mobile screen width (<768px).
  - Reduces hexBinResolution (4 -> 2) for performance.
  - Disables heavy umpImageUrl (topology texture).
  - Adjusts zoom levels and pin sizes for smaller screens.
  - Slows down auto-rotation speed.

### Testing
- [x] Desktop: Full fidelity, terminal docked.
- [x] Mobile (Simulated): Reduced fidelity, terminal collapsible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves mobile experience for the chat terminal and 3D globe while preserving desktop behavior.
> 
> - **Responsive `ChatTerminal`**: Adds `isOpen` state with a floating toggle button on mobile; terminal slides up bottom-half on small screens and remains docked on desktop; conditionally disables input `autoFocus` on mobile.
> - **Mobile-aware `LivingGlobe`**: Detects screen width to tune rendering—disables `bumpImageUrl` on mobile, lowers `hexBinResolution`, adjusts pin/satellite sizes and `pathStroke`, slows `autoRotateSpeed`, and sets less aggressive zoom for clicks/initial POV.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b570373a4c8419aa0fe878fd2a2af8acaf40afff. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat terminal now includes a toggle button on mobile devices, allowing users to open and close the terminal window as needed.
  * Globe visualization now optimizes rendering for mobile devices with improved performance and visibility adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->